### PR TITLE
Handle 204 - No Content response

### DIFF
--- a/src/main/java/io/grisu/eecore/utils/AsyncResponseIFace.java
+++ b/src/main/java/io/grisu/eecore/utils/AsyncResponseIFace.java
@@ -26,6 +26,8 @@ public interface AsyncResponseIFace {
 
     <T> BiConsumer<T, Throwable> justOk(javax.ws.rs.container.AsyncResponse response);
 
+    <T> BiConsumer<T, Throwable> noContent(javax.ws.rs.container.AsyncResponse response);
+
     <T, U, E> BiConsumer<T, Throwable> handle(javax.ws.rs.container.AsyncResponse response, Function<T, U> resultTransformer, Supplier<E> alternativeResultSupplier);
 
     <T> BiConsumer<T, Throwable> created(javax.ws.rs.container.AsyncResponse response, Function<T, String> t);

--- a/src/main/java/io/grisu/eecore/utils/AsyncResponseUtils.java
+++ b/src/main/java/io/grisu/eecore/utils/AsyncResponseUtils.java
@@ -68,6 +68,11 @@ public class AsyncResponseUtils implements AsyncResponseIFace {
     }
 
     @Override
+    public <T> BiConsumer<T, Throwable> noContent(AsyncResponse response) {
+        return justOutput(response, Response.noContent().build());
+    }
+
+    @Override
     public <T, U, E> BiConsumer<T, Throwable> handle(AsyncResponse response, Function<T, U> resultTransformer, Supplier<E> alternativeResultSupplier) {
         return (result, ex) -> {
             if (ex != null) {


### PR DESCRIPTION
Hi @lordkada,
I'd like to add the `noContent` method to handle responses with status code 204 since I often use it as response of `DELETE` requests.
I hope this can be useful for you as well.